### PR TITLE
chore(ci): update Go version matrix and fix YAML indentation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,20 +1,20 @@
 on:
-  push:
-    branches: ["dev"]
-  pull_request:
-    branches: ["main"]
+    push:
+        branches: ["dev"]
+    pull_request:
+        branches: ["main"]
 name: Test
 jobs:
-  test:
-    strategy:
-      matrix:
-        go-version: [1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: "${{ matrix.go-version }}"
-      - uses: actions/checkout@v3
-      - name: Test
-        run: go mod tidy && go test -v ./test/...
+    test:
+        strategy:
+            matrix:
+                go-version: [1.21.x, 1.22.x, 1.23.x, 1.24.x, 1.25.x]
+                os: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: ${{ matrix.os }}
+        steps:
+            - uses: actions/setup-go@v4
+              with:
+                  go-version: "${{ matrix.go-version }}"
+            - uses: actions/checkout@v3
+            - name: Test
+              run: go mod tidy && go test -v ./test/...


### PR DESCRIPTION
- Update Go versions from [1.19-1.23] to [1.21-1.25]
- Fix YAML indentation consistency (4 spaces)