### PR TITLE
feat(pool): add maxSize capacity cap with ErrPoolFull on Put overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Every pooled object is wrapped in an `Element` (from `sync.Pool`). The backgroun
 | `New(q, conf)`  | Create a pool with the given queue and config                             |
 | `Get()`         | Borrow an element; returns `ErrPoolEmpty` if the pool is empty            |
 | `GetOrCreate()` | Borrow an element, or call `NewFunc` if pool is empty                     |
-| `Put(data)`     | Return an element to the pool; returns `ErrValueIsNil` if data is nil     |
+| `Put(data)`     | Return an element to the pool; returns `ErrValueIsNil` if data is nil, `ErrPoolFull` when the pool is at maximum capacity |
 | `Stop()`        | Graceful shutdown: close all elements, stop supervision                   |
 | `Len()`         | Current number of pooled elements                                         |
 | `Cleanup()`     | Destroy all elements immediately and drain the queue                      |
@@ -91,6 +91,7 @@ Every pooled object is wrapped in an `Element` (from `sync.Pool`). The backgroun
 - After `Stop()`, all pool methods return `ErrQueueClosed`.
 - `Get()` on an empty pool returns the pre-allocated sentinel `ErrPoolEmpty` (zero-allocation hot path); use `errors.Is(err, conecta.ErrPoolEmpty)` to detect it.
 - `Put(nil)` returns `ErrValueIsNil`.
+- `Put(data)` returns the pre-allocated sentinel `ErrPoolFull` when the pool is at maximum capacity. Ownership never transfers on a failed `Put` — the caller keeps responsibility for the value.
 
 ### Configuration
 
@@ -103,6 +104,7 @@ Build a `Config` with the fluent builder API:
 | `WithCloseFunc(f)`      | Cleanup: `func(any) error`                  | `DefaultCloseFunc` |
 | `WithCallback(c)`       | Lifecycle observer (`Callback` interface)   | empty callback     |
 | `WithInitialize(n)`     | Pre-create `n` elements at startup          | `0`                |
+| `WithMaxSize(n)`        | Maximum number of elements the pool can hold; `Put` returns `ErrPoolFull` when full (values <= 0 fall back to the default) | `1024`             |
 | `WithPingMaxRetries(n)` | Ping failures before destroying an element  | `3`                |
 | `WithScanInterval(ms)`  | Supervision scan interval in milliseconds (values below `300` are clamped to `300`) | `10000`            |
 
@@ -143,6 +145,7 @@ type Callback interface {
 
 - **`Put` transfers ownership** — never `Put` the same value twice; it could be lent out to two callers concurrently and closed twice.
 - **`Len()` may count tombstones** — elements destroyed by supervision stay in the queue (and in `Len()`) until a later `Get()` reclaims them.
+- **The max size bounds how many elements the pool holds** — tombstones (elements destroyed by supervision but not yet reclaimed by a `Get()`) keep occupying capacity until reclaimed; on-demand creation by `GetOrCreate()` is not constrained by the max size.
 - **Values lent out at `Stop()` or `Cleanup()` are not closed by the pool** — if `Stop()` or a standalone `Cleanup()` runs while a value is lent out, closing it is the borrower's responsibility.
 - **User hooks run in the supervise goroutine** — `pingFunc`, `closeFunc`, and `Callback` methods must return quickly, and `pingFunc` must enforce its own timeout. Never call `Stop()` from inside these hooks: `Stop()` waits for the supervise goroutine to exit, so it would self-deadlock. Do not call back into the pool from `closeFunc`/`OnClose` either (the queue lock is held during `Cleanup`).
 
@@ -152,12 +155,12 @@ Optimized with `sync.Pool` wrapper reuse and mutex-free access on the hot path. 
 
 | Benchmark           |   Time/op | Allocs/op | Notes                                          |
 | ------------------- | --------: | --------: | ---------------------------------------------- |
-| `Get`               |  71.08 ns |   0 alloc | Steady-state borrow (Get + immediate put-back) |
-| `Put`               |  261.1 ns |   2 alloc | Queue node + Element wrapper                   |
-| `GetAndPut`         |  71.54 ns |   0 alloc | Round-trip amortizes wrapper cost              |
-| `GetOrCreate`       |  21.21 ns |   0 alloc | Falls through to `NewFunc`                     |
-| `ConcurrentMixed_8` |  372.7 ns |   1 alloc | 8 goroutines, 50% get + 50% put                |
-| `Supervise_10`      |  977.9 ns |   0 alloc | 10-element pool scan proxy                     |
+| `Get`               |  83.03 ns |   0 alloc | Steady-state borrow (Get + immediate put-back) |
+| `Put`               |  277.8 ns |   2 alloc | Queue node + Element wrapper                   |
+| `GetAndPut`         |  82.43 ns |   0 alloc | Round-trip amortizes wrapper cost              |
+| `GetOrCreate`       |  20.65 ns |   0 alloc | Falls through to `NewFunc`                     |
+| `ConcurrentMixed_8` |  380.0 ns |   1 alloc | 8 goroutines, 50% get + 50% put                |
+| `Supervise_10`      |   1080 ns |   0 alloc | 10-element pool scan proxy                     |
 
 ## Examples
 

--- a/config.go
+++ b/config.go
@@ -12,6 +12,10 @@ const (
 	// DefaultInitialize is the default number of elements to initialize
 	DefaultInitialize = 0
 
+	// DefaultMaxSize 是默认连接池最大容量
+	// DefaultMaxSize is the default maximum capacity of the pool
+	DefaultMaxSize = 1024
+
 	// DefaultMaxPingRetry 是默认的最大 ping 重试次数
 	// DefaultMaxPingRetry is the default maximum number of ping retries
 	DefaultMaxPingRetry = 3
@@ -52,6 +56,10 @@ type Config struct {
 	// Number of elements to initialize
 	initialize int
 
+	// 连接池最大容量（池内最多持有的元素数）
+	// Maximum capacity of the pool (maximum number of elements the pool can hold)
+	maxSize int
+
 	// 扫描全部对象实例间隔
 	// Interval to scan all object instances
 	scanInterval int
@@ -82,6 +90,10 @@ func NewConfig() *Config {
 		// 默认的初始化元素数量
 		// Default number of elements to initialize
 		initialize: DefaultInitialize,
+
+		// 默认的连接池最大容量
+		// Default maximum capacity of the pool
+		maxSize: DefaultMaxSize,
 
 		// 默认的最大重试次数
 		// Default maximum number of retries
@@ -126,6 +138,13 @@ func (c *Config) WithCallback(callback Callback) *Config {
 // WithInitialize is the method to set the number of elements to initialize
 func (c *Config) WithInitialize(init int) *Config {
 	c.initialize = init
+	return c
+}
+
+// WithMaxSize 是设置连接池最大容量的方法
+// WithMaxSize is the method to set the maximum capacity of the pool
+func (c *Config) WithMaxSize(maxSize int) *Config {
+	c.maxSize = maxSize
 	return c
 }
 
@@ -180,6 +199,18 @@ func normalizeConfig(conf *Config) *Config {
 		// If the maximum number of retries is less than or equal to 0 or greater than or equal to the maximum unsigned 16-bit integer, set it to the default maximum Ping retry count
 		if conf.maxRetries <= 0 || conf.maxRetries >= math.MaxUint16 {
 			conf.maxRetries = DefaultMaxPingRetry
+		}
+
+		// 如果最大容量小于等于0，回落到默认最大容量（必须先于 initialize 钳制执行）
+		// If the maximum capacity is less than or equal to 0, fall back to the default maximum capacity (must run before the initialize clamp)
+		if conf.maxSize <= 0 {
+			conf.maxSize = DefaultMaxSize
+		}
+
+		// 如果初始化元素数量超过最大容量，钳制到最大容量
+		// If the number of elements to initialize exceeds the maximum capacity, clamp it to the maximum capacity
+		if conf.initialize > conf.maxSize {
+			conf.initialize = conf.maxSize
 		}
 
 		// 如果扫描间隔小于扫描间隔下限，钳制到下限

--- a/pool.go
+++ b/pool.go
@@ -25,6 +25,10 @@ var (
 	// ErrPoolEmpty indicates the pool has no element available to borrow
 	ErrPoolEmpty = errors.New("pool is empty")
 
+	// ErrPoolFull 表示池已达到最大容量，无法再接收新元素
+	// ErrPoolFull indicates the pool has reached its maximum capacity and cannot accept new elements
+	ErrPoolFull = errors.New("pool is full")
+
 	// ErrValueIsNil 表示要放入池中的元素为 nil
 	// ErrValueIsNil indicates the element to be put into the pool is nil
 	ErrValueIsNil = errors.New("value is nil")
@@ -42,6 +46,7 @@ type Pool struct {
 	elementPool *pool.ElementPool  // Pool for element objects / 元素对象池
 	stopGate    sync.RWMutex       // Stop 门闩，防止 Stop 窗口期并发 Put 泄漏 / stop gate preventing concurrent Put leaks during Stop window
 	stopped     atomic.Bool        // 停止标记位，热路径免锁快速判定 / lock-free stop flag for hot paths
+	size        atomic.Int64       // 当前池内元素计数，镜像 queue.Len() 语义（含 tombstone）；无锁原子量，不参与 stopGate→queue.lock→element.mu 锁序 / current element count in the pool, mirroring queue.Len() semantics (including tombstones); lock-free atomic outside the stopGate→queue.lock→element.mu lock order
 }
 
 // New creates a new Pool instance with the given queue and configuration
@@ -112,6 +117,9 @@ func (p *Pool) initialize() error {
 			p.drainAndClose()
 			return err
 		}
+		// 入队成功：池内计数加一。免容量检查——normalizeConfig 已保证 initialize ≤ maxSize，且发生在 New 返回前无并发
+		// Enqueue succeeded: increment the pool count. Capacity check is exempt — normalizeConfig already guarantees initialize ≤ maxSize, and this runs before New returns with no concurrency
+		p.size.Add(1)
 	}
 
 	// All elements successfully enqueued; caller (Stop/Cleanup) is responsible for cleanup
@@ -128,6 +136,9 @@ func (p *Pool) drainAndClose() {
 			break
 		}
 		p.queue.Done(elem)
+		// 元素离队：池内计数减一
+		// The element left the queue: decrement the pool count
+		p.size.Add(-1)
 		wrapper := elem.(*pool.Element)
 		if v := wrapper.GetData(); v != nil {
 			_ = p.config.closeFunc(v)
@@ -185,6 +196,9 @@ func (p *Pool) Cleanup() {
 			break
 		}
 		p.queue.Done(element)
+		// 元素离队：池内计数减一
+		// The element left the queue: decrement the pool count
+		p.size.Add(-1)
 		wrapper := element.(*pool.Element)
 		// 关闭守卫：standalone Cleanup 期间并发 Put 进入的元素（阶段1 Range 之后入队）仍持有 data，
 		// 按认领模式关闭，避免被静默丢失关闭
@@ -236,6 +250,10 @@ func (p *Pool) Get() (any, error) {
 			return nil, ErrPoolEmpty
 		}
 		p.queue.Done(element)
+
+		// 元素离队即减容量：单点递减同时覆盖 tombstone 回收与借出两个分支
+		// Decrement on dequeue: this single point covers both the tombstone reclaim and the lend-out branches
+		p.size.Add(-1)
 
 		wrapper := element.(*pool.Element)
 		wrapper.Lock()
@@ -293,11 +311,27 @@ func (p *Pool) Put(data any) error {
 	if p.stopped.Load() || p.queue.IsClosed() {
 		return ErrQueueClosed
 	}
+
+	// CAS 预留一个容量槽位；池满时返回预分配哨兵 ErrPoolFull（零分配，容量检查位于 closed 检查之后）
+	// Reserve a capacity slot via CAS; return the pre-allocated sentinel ErrPoolFull when full (zero allocation, the capacity check runs after the closed check)
+	for {
+		cur := p.size.Load()
+		if cur >= int64(p.config.maxSize) {
+			return ErrPoolFull
+		}
+		if p.size.CompareAndSwap(cur, cur+1) {
+			break
+		}
+	}
+
 	element := p.elementPool.Get()
 	// wrapper 来自 elementPool（sync.Pool 返回的独占对象），在 queue.Put 发布前为当前 goroutine 独占，无需加锁
 	// The wrapper obtained from elementPool (an exclusive object returned by sync.Pool) is exclusively owned by this goroutine before being published via queue.Put, no lock needed
 	element.SetDataNoLock(data)
 	if err := p.queue.Put(element); err != nil {
+		// 入队失败：先释放已预留的容量槽位，再归还 wrapper
+		// Enqueue failed: release the reserved capacity slot first, then return the wrapper
+		p.size.Add(-1)
 		p.elementPool.Put(element)
 		// 队列被并发关闭时统一映射为 ErrQueueClosed；其余错误（如幂等队列的 AlreadyExist）原样透传
 		// Map a concurrently closed queue to ErrQueueClosed; pass through other errors (e.g. AlreadyExist from idempotent queues) as-is

--- a/test/bench_pool_test.go
+++ b/test/bench_pool_test.go
@@ -25,16 +25,31 @@ func benchPingFunc(_ any, _ int) bool { return true }
 // benchCloseFunc is a no-op close function.
 func benchCloseFunc(_ any) error { return nil }
 
-// newBenchPool creates a pool configured for benchmarking.
+// newBenchPool 创建默认容量上限（conecta.DefaultMaxSize）的基准池，
+// 是 newBenchPoolWithMaxSize 的默认容量版本（委托实现，行为完全等价）。
+// scanInterval=10000ms 使后台监控 goroutine 保持近似休眠，避免干扰测量精度。
+// newBenchPool creates a benchmark pool with the default capacity cap
+// (conecta.DefaultMaxSize); it is the default-capacity variant of
+// newBenchPoolWithMaxSize (implemented by delegation, behaviorally identical).
 // scanInterval=10000ms keeps the background monitor goroutine effectively
 // dormant, preventing interference with measurement accuracy.
 func newBenchPool() *conecta.Pool {
+	return newBenchPoolWithMaxSize(conecta.DefaultMaxSize)
+}
+
+// newBenchPoolWithMaxSize 创建一个显式设置容量上限的基准池，
+// 供池规模随 b.N 增长（或预填充量超过默认上限）的基准使用。
+// newBenchPoolWithMaxSize creates a benchmark pool with an explicit capacity
+// limit, for benchmarks whose pool grows with b.N (or whose pre-fill exceeds
+// the default cap).
+func newBenchPoolWithMaxSize(maxSize int) *conecta.Pool {
 	queue := wkq.NewQueue(nil)
 	conf := conecta.NewConfig().
 		WithNewFunc(benchNewFunc).
 		WithPingFunc(benchPingFunc).
 		WithCloseFunc(benchCloseFunc).
-		WithScanInterval(10000)
+		WithScanInterval(10000).
+		WithMaxSize(maxSize)
 	p, err := conecta.New(queue, conf)
 	if err != nil {
 		panic(err)
@@ -87,7 +102,13 @@ func BenchmarkPool_Put(b *testing.B) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	p := newBenchPool()
+	// 池随 b.N 无界增长：注入 b.N + 1024 的容量上限（统一公式余量，本基准无预填充），
+	// 避免默认 maxSize=1024 把超限迭代短路到 ErrPoolFull 拒绝路径，改变测量语义。
+	// The pool grows unbounded with b.N: inject a b.N + 1024 capacity cap
+	// (unified-formula margin; this benchmark has no pre-fill) so the default
+	// maxSize=1024 never short-circuits iterations onto the ErrPoolFull
+	// rejection path and changes the semantics.
+	p := newBenchPoolWithMaxSize(b.N + 1024)
 	defer p.Stop()
 
 	b.ResetTimer()
@@ -172,7 +193,14 @@ func BenchmarkPool_ConcurrentGet_8(b *testing.B) {
 		fillSize   = numWorkers * 1000 // 8000
 	)
 
-	p := newBenchPool()
+	// 预填充 8000 个元素超过默认 maxSize=1024：显式放宽容量上限为
+	// max(b.N+1024, fillSize)；max 保证低 b.N 的预热轮次也能容纳全部填充量，
+	// 避免填充被 ErrPoolFull 静默截断（正式测量轮次 b.N 远大于填充量时取 b.N+1024）。
+	// The 8000-element pre-fill exceeds the default maxSize=1024: widen the cap
+	// explicitly to max(b.N+1024, fillSize); max guarantees the fill fully fits
+	// even in warm-up rounds with a small b.N, so the fill is not silently
+	// truncated by ErrPoolFull (b.N+1024 dominates in measured rounds).
+	p := newBenchPoolWithMaxSize(max(b.N+1024, fillSize))
 	defer p.Stop()
 	fillPool(p, fillSize)
 
@@ -210,7 +238,13 @@ func BenchmarkPool_ConcurrentPut_8(b *testing.B) {
 
 	const numWorkers = 8
 
-	p := newBenchPool()
+	// 池随 b.N 无界增长：注入 b.N + 1024 的容量上限（统一公式余量，本基准无预填充），
+	// 避免默认 maxSize=1024 把超限迭代短路到 ErrPoolFull 拒绝路径，改变测量语义。
+	// The pool grows unbounded with b.N: inject a b.N + 1024 capacity cap
+	// (unified-formula margin; this benchmark has no pre-fill) so the default
+	// maxSize=1024 never short-circuits iterations onto the ErrPoolFull
+	// rejection path and changes the semantics.
+	p := newBenchPoolWithMaxSize(b.N + 1024)
 	defer p.Stop()
 
 	b.ResetTimer()
@@ -265,7 +299,14 @@ func benchmarkConcurrentMixed(b *testing.B, numWorkers int) {
 
 	const fillSize = 1000
 
-	p := newBenchPool()
+	// 预填充后池仍随 b.N 净增长（约半数迭代为纯 Put）：注入 b.N + 1024 的容量
+	// 上限（余量覆盖填充量），避免默认 maxSize=1024 把超限迭代短路到
+	// ErrPoolFull 拒绝路径，改变混合负载的测量语义。
+	// After the pre-fill the pool still grows with b.N (about half of the
+	// iterations are pure Puts): inject a b.N + 1024 capacity cap (margin covers
+	// the fill) so the default maxSize=1024 never short-circuits iterations onto
+	// the ErrPoolFull rejection path and changes the mixed-workload semantics.
+	p := newBenchPoolWithMaxSize(b.N + 1024)
 	defer p.Stop()
 	fillPool(p, fillSize)
 

--- a/test/pool_test.go
+++ b/test/pool_test.go
@@ -678,3 +678,333 @@ func TestPool_Maintain_MultipleConnections(t *testing.T) {
 	assert.Equal(t, int64(0), atomic.LoadInt64(&closeCount), "Close should not be called for healthy connections")
 	assert.Equal(t, 2, p.Len(), "Connections should remain in pool")
 }
+
+// TestPool_MaxSize_Default 测试默认最大容量锚点：连续 Put 1024 个成功，第 1025 个返回 ErrPoolFull
+// TestPool_MaxSize_Default tests the default capacity anchor: 1024 Puts succeed and the 1025th returns ErrPoolFull
+func TestPool_MaxSize_Default(t *testing.T) {
+	queue := wkq.NewQueue(nil)
+	p, err := conecta.New(queue, nil)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	defer p.Stop()
+
+	// 默认容量为 1024：前 1024 次 Put 全部成功（使用轻量 int 值）
+	// The default capacity is 1024: all of the first 1024 Puts succeed (using lightweight int values)
+	for i := range 1024 {
+		require.NoError(t, p.Put(i))
+	}
+
+	// 第 1025 次 Put 触发容量上限，返回预分配哨兵 ErrPoolFull
+	// The 1025th Put hits the capacity limit and returns the pre-allocated sentinel ErrPoolFull
+	err = p.Put(0)
+	assert.True(t, errors.Is(err, conecta.ErrPoolFull))
+	assert.Equal(t, 1024, p.Len())
+}
+
+// TestPool_MaxSize_WithMaxSize 测试 WithMaxSize 配置生效：容量满后 Put 返回 ErrPoolFull
+// TestPool_MaxSize_WithMaxSize tests the WithMaxSize setting takes effect: Put returns ErrPoolFull when full
+func TestPool_MaxSize_WithMaxSize(t *testing.T) {
+	queue := wkq.NewQueue(nil)
+	conf := conecta.NewConfig().WithMaxSize(2)
+	assert.NotNil(t, conf)
+
+	p, err := conecta.New(queue, conf)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	defer p.Stop()
+
+	require.NoError(t, p.Put("item1"))
+	require.NoError(t, p.Put("item2"))
+
+	// 容量已满：第 3 次 Put 返回 ErrPoolFull，队列长度保持为 2
+	// Capacity is full: the 3rd Put returns ErrPoolFull and the queue length stays at 2
+	err = p.Put("item3")
+	assert.True(t, errors.Is(err, conecta.ErrPoolFull))
+	assert.Equal(t, 2, p.Len())
+}
+
+// TestPool_MaxSize_RecoveryAfterGet 测试容量恢复：借出元素释放容量后 Put 重新成功
+// TestPool_MaxSize_RecoveryAfterGet tests capacity recovery: after a Get frees capacity, Put succeeds again
+func TestPool_MaxSize_RecoveryAfterGet(t *testing.T) {
+	queue := wkq.NewQueue(nil)
+	conf := conecta.NewConfig().WithMaxSize(2)
+	assert.NotNil(t, conf)
+
+	p, err := conecta.New(queue, conf)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	defer p.Stop()
+
+	require.NoError(t, p.Put("item1"))
+	require.NoError(t, p.Put("item2"))
+	assert.True(t, errors.Is(p.Put("item3"), conecta.ErrPoolFull))
+
+	// Get 借出 1 个元素，释放 1 单位容量
+	// Get borrows one element and frees one unit of capacity
+	data, err := p.Get()
+	require.NoError(t, err)
+	assert.Equal(t, "item1", data)
+
+	// 容量恢复：Put 重新成功，池回到满容量状态
+	// Capacity recovered: Put succeeds again and the pool returns to full capacity
+	require.NoError(t, p.Put("item3"))
+	assert.Equal(t, 2, p.Len())
+}
+
+// TestPool_MaxSize_TombstoneOccupiesCapacity 测试 tombstone 占用容量：被销毁未回收的元素继续占容量直至 Get 回收
+// TestPool_MaxSize_TombstoneOccupiesCapacity tests tombstones occupy capacity: destroyed but unreclaimed elements keep occupying capacity until Get reclaims them
+func TestPool_MaxSize_TombstoneOccupiesCapacity(t *testing.T) {
+	queue := wkq.NewQueue(nil)
+	var closeCount int64
+
+	conf := conecta.NewConfig().
+		WithMaxSize(2).
+		WithInitialize(2).
+		WithScanInterval(300).
+		WithPingMaxRetries(1).
+		WithNewFunc(func() (any, error) { return "conn", nil }).
+		WithPingFunc(func(any, int) bool { return false }).
+		WithCloseFunc(func(any) error {
+			atomic.AddInt64(&closeCount, 1)
+			return nil
+		})
+	assert.NotNil(t, conf)
+
+	p, err := conecta.New(queue, conf)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	defer p.Stop()
+
+	// 等待 supervise 销毁两个元素（恒 false 的 pingFunc + 单次重试上限）
+	// Wait for supervise to destroy both elements (always-false pingFunc + retry limit of 1)
+	assert.Eventually(t, func() bool {
+		return atomic.LoadInt64(&closeCount) == 2
+	}, 5*time.Second, 50*time.Millisecond, "Both elements should be destroyed")
+
+	// tombstone 仍留在队列中占用容量
+	// Tombstones remain in the queue and still occupy capacity
+	assert.Equal(t, 2, p.Len())
+	assert.True(t, errors.Is(p.Put("intruder"), conecta.ErrPoolFull))
+
+	// 单次 Get 回收两个 tombstone 后返回 ErrPoolEmpty
+	// A single Get reclaims both tombstones and then returns ErrPoolEmpty
+	_, err = p.Get()
+	assert.True(t, errors.Is(err, conecta.ErrPoolEmpty))
+
+	// 容量已释放：Put 重新成功
+	// Capacity has been released: Put succeeds again
+	require.NoError(t, p.Put("fresh"))
+	assert.Equal(t, 1, p.Len())
+}
+
+// TestPool_MaxSize_Fallback 测试归一化回落：maxSize<=0 时回落为默认容量 1024
+// TestPool_MaxSize_Fallback tests normalization fallback: maxSize <= 0 falls back to the default capacity 1024
+func TestPool_MaxSize_Fallback(t *testing.T) {
+	for _, maxSize := range []int{0, -1} {
+		t.Run(fmt.Sprintf("maxSize=%d", maxSize), func(t *testing.T) {
+			queue := wkq.NewQueue(nil)
+			p, err := conecta.New(queue, conecta.NewConfig().WithMaxSize(maxSize))
+			require.NoError(t, err)
+			require.NotNil(t, p)
+			defer p.Stop()
+
+			// 行为与默认一致：1024 次成功，第 1025 次返回 ErrPoolFull
+			// Behaves like the default: 1024 successes, the 1025th returns ErrPoolFull
+			for i := range 1024 {
+				require.NoError(t, p.Put(i))
+			}
+			assert.True(t, errors.Is(p.Put(0), conecta.ErrPoolFull))
+		})
+	}
+}
+
+// TestPool_MaxSize_InitializeClamped 测试归一化顺序：initialize 钳制发生在 maxSize 回落之后
+// TestPool_MaxSize_InitializeClamped tests normalization order: the initialize clamp happens after the maxSize fallback
+func TestPool_MaxSize_InitializeClamped(t *testing.T) {
+	newFunc := func() (any, error) { return "conn", nil }
+
+	t.Run("initialize clamped to maxSize", func(t *testing.T) {
+		queue := wkq.NewQueue(nil)
+		conf := conecta.NewConfig().WithMaxSize(3).WithInitialize(5).WithNewFunc(newFunc)
+		assert.NotNil(t, conf)
+
+		p, err := conecta.New(queue, conf)
+		require.NoError(t, err)
+		require.NotNil(t, p)
+		defer p.Stop()
+
+		// initialize(5) 被钳制到 maxSize(3)
+		// initialize(5) is clamped to maxSize(3)
+		assert.Equal(t, 3, p.Len())
+	})
+
+	t.Run("maxSize fallback before clamp", func(t *testing.T) {
+		queue := wkq.NewQueue(nil)
+		conf := conecta.NewConfig().WithMaxSize(0).WithInitialize(5).WithNewFunc(newFunc)
+		assert.NotNil(t, conf)
+
+		p, err := conecta.New(queue, conf)
+		require.NoError(t, err)
+		require.NotNil(t, p)
+		defer p.Stop()
+
+		// maxSize(0) 先回落为 1024，initialize(5) 保持不变
+		// maxSize(0) falls back to 1024 first, so initialize(5) is kept as-is
+		assert.Equal(t, 5, p.Len())
+	})
+}
+
+// TestPool_MaxSize_NilBeatsFull 测试错误优先级：Put(nil) 返回 ErrValueIsNil 而非 ErrPoolFull
+// TestPool_MaxSize_NilBeatsFull tests error priority: Put(nil) returns ErrValueIsNil instead of ErrPoolFull
+func TestPool_MaxSize_NilBeatsFull(t *testing.T) {
+	queue := wkq.NewQueue(nil)
+	p, err := conecta.New(queue, conecta.NewConfig().WithMaxSize(1))
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	defer p.Stop()
+
+	// 先填满池
+	// Fill the pool first
+	require.NoError(t, p.Put("item1"))
+
+	// nil 检查优先于容量检查
+	// The nil check takes priority over the capacity check
+	err = p.Put(nil)
+	assert.Equal(t, conecta.ErrValueIsNil, err)
+}
+
+// TestPool_MaxSize_StopBeatsFull 测试错误优先级：满池 Stop 后 Put 返回 ErrQueueClosed 而非 ErrPoolFull
+// TestPool_MaxSize_StopBeatsFull tests error priority: after Stop on a full pool, Put returns ErrQueueClosed instead of ErrPoolFull
+func TestPool_MaxSize_StopBeatsFull(t *testing.T) {
+	queue := wkq.NewQueue(nil)
+	p, err := conecta.New(queue, conecta.NewConfig().WithMaxSize(1))
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	// 先填满池，再停止
+	// Fill the pool first, then stop it
+	require.NoError(t, p.Put("item1"))
+	p.Stop()
+
+	// 已停止检查优先于容量检查
+	// The stopped check takes priority over the capacity check
+	err = p.Put("item2")
+	assert.Equal(t, conecta.ErrQueueClosed, err)
+	assert.False(t, errors.Is(err, conecta.ErrPoolFull))
+}
+
+// TestPool_MaxSize_GetOrCreateUnlimited 测试 GetOrCreate 的按需创建不受 maxSize 约束
+// TestPool_MaxSize_GetOrCreateUnlimited tests that GetOrCreate's on-demand creation is not constrained by maxSize
+func TestPool_MaxSize_GetOrCreateUnlimited(t *testing.T) {
+	queue := wkq.NewQueue(nil)
+	var createCount int64
+
+	conf := conecta.NewConfig().
+		WithMaxSize(1).
+		WithInitialize(1).
+		WithNewFunc(func() (any, error) {
+			atomic.AddInt64(&createCount, 1)
+			return "created", nil
+		})
+	assert.NotNil(t, conf)
+
+	p, err := conecta.New(queue, conf)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	defer p.Stop()
+
+	// 初始化阶段 newFunc 已被调用一次（创建唯一的初始化元素）
+	// newFunc has already been called once during initialization (creating the single initialized element)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&createCount))
+
+	// 首次 GetOrCreate 借出已初始化元素，不再调用 newFunc
+	// The first GetOrCreate borrows the initialized element without calling newFunc
+	data, err := p.GetOrCreate()
+	require.NoError(t, err)
+	assert.Equal(t, "created", data)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&createCount))
+	assert.Equal(t, 0, p.Len())
+
+	// 池空时 GetOrCreate 按需创建成功，不受 maxSize=1 约束
+	// On an empty pool, GetOrCreate creates on demand successfully, unconstrained by maxSize=1
+	data, err = p.GetOrCreate()
+	require.NoError(t, err)
+	assert.Equal(t, "created", data)
+	assert.Equal(t, int64(2), atomic.LoadInt64(&createCount))
+	assert.Equal(t, 0, p.Len())
+}
+
+// TestPool_MaxSize_ConcurrentHardLimit 测试并发硬上限：CAS 预留语义保证成功数恰好等于 maxSize
+// TestPool_MaxSize_ConcurrentHardLimit tests the concurrent hard limit: CAS reservation guarantees the success count equals exactly maxSize
+func TestPool_MaxSize_ConcurrentHardLimit(t *testing.T) {
+	queue := wkq.NewQueue(nil)
+	p, err := conecta.New(queue, conecta.NewConfig().WithMaxSize(50))
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	defer p.Stop()
+
+	// 8 个 goroutine 各 Put 20 次，共 160 次并发 Put
+	// 8 goroutines each Put 20 times, 160 concurrent Puts in total
+	var wg sync.WaitGroup
+	var success, full, other int64
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 20 {
+				err := p.Put("conn")
+				if err == nil {
+					atomic.AddInt64(&success, 1)
+				} else if errors.Is(err, conecta.ErrPoolFull) {
+					atomic.AddInt64(&full, 1)
+				} else {
+					atomic.AddInt64(&other, 1)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	// 成功数恰好为 50，其余 110 次全部为 ErrPoolFull，无其他错误
+	// Exactly 50 succeed; the other 110 all return ErrPoolFull with no other errors
+	assert.Equal(t, int64(50), atomic.LoadInt64(&success))
+	assert.Equal(t, int64(110), atomic.LoadInt64(&full))
+	assert.Equal(t, int64(0), atomic.LoadInt64(&other))
+	assert.Equal(t, 50, p.Len())
+}
+
+// TestPool_MaxSize_FullNoOwnershipTransfer 测试满池 Put 失败不转移所有权：被拒 value 不会被池关闭
+// TestPool_MaxSize_FullNoOwnershipTransfer tests a full-pool Put failure does not transfer ownership: the rejected value is not closed by the pool
+func TestPool_MaxSize_FullNoOwnershipTransfer(t *testing.T) {
+	queue := wkq.NewQueue(nil)
+	// closeFunc 记录器：记录所有被池关闭的 value
+	// closeFunc recorder: records every value closed by the pool
+	var mu sync.Mutex
+	var closed []string
+
+	conf := conecta.NewConfig().WithMaxSize(1).WithCloseFunc(func(v any) error {
+		mu.Lock()
+		closed = append(closed, v.(string))
+		mu.Unlock()
+		return nil
+	})
+	assert.NotNil(t, conf)
+
+	p, err := conecta.New(queue, conf)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	require.NoError(t, p.Put("resident"))
+	// 池满：Put 失败，所有权不转移
+	// Pool is full: Put fails and ownership is not transferred
+	assert.True(t, errors.Is(p.Put("intruder"), conecta.ErrPoolFull))
+
+	p.Stop()
+
+	// Stop 后只有成功入队的 resident 被关闭；intruder 未被池关闭（仍由调用者负责）
+	// After Stop only the successfully enqueued resident is closed; the intruder is not closed by the pool (still the caller's responsibility)
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Contains(t, closed, "resident")
+	assert.NotContains(t, closed, "intruder")
+}


### PR DESCRIPTION
- config: DefaultMaxSize=1024, WithMaxSize builder, normalizeConfig clamps (maxSize<=0 falls back to default; initialize clamped to maxSize)

- pool: atomic size counter mirroring queue.Len() semantics (incl. tombstones); Put reserves a slot via CAS and returns pre-allocated ErrPoolFull sentinel when full; slot released on enqueue failure; exclusive ownership never transfers on failed Put

- tests: +330 lines covering capacity enforcement, concurrent Put overflow, tombstone accounting

- bench: capacity-cap injection for b.N-growing benchmarks (max(b.N+1024, fillSize) floor for pre-filled ConcurrentGet_8), accurate bilingual injection comments, newBenchPool deduplicated via delegation to newBenchPoolWithMaxSize(DefaultMaxSize)

- docs: README API table, semantics notes and refreshed benchmark numbers